### PR TITLE
Add Claude Code plugin support and skill metadata

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
+  "name": "ai-context-kit",
+  "version": "1.4.0",
+  "description": "Context-aware AI collaboration skills for creating and validating user context, project AGENTS.md files, and skill artifacts across LLM providers.",
+  "author": {
+    "name": "MSiccDev Software Development",
+    "url": "https://github.com/MSiccDev"
+  },
+  "homepage": "https://github.com/MSiccDev/ai-context-kit",
+  "repository": "https://github.com/MSiccDev/ai-context-kit",
+  "license": "MIT",
+  "keywords": [
+    "context",
+    "agents",
+    "skills",
+    "user-context",
+    "ai-collaboration",
+    "prompt-engineering"
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -294,6 +294,51 @@ If paths must change, update the specification and README first, then adjust ski
 | **Local scripts / APIs** | Concatenate user context + `AGENTS.md` when initializing conversations | Context window management is your responsibility; monitor token usage for long sessions |
 | **Other platforms** | Use the platform's context management capabilities (project knowledge, system instructions, or initial prompt injection) | Method and limits vary; consult platform documentation |
 
+---
+
+## Installing as a Claude Code Plugin
+
+AI Context Kit is distributed as a native Claude Code plugin. Installing it gives you all 9 skills available directly in your Claude Code sessions without cloning or forking the repository.
+
+### Install
+
+```bash
+claude plugin install ai-context-kit@MSiccDev/ai-context-kit
+```
+
+This installs the plugin at user scope (`~/.claude/settings.json`). To install for a specific project only:
+
+```bash
+claude plugin install ai-context-kit@MSiccDev/ai-context-kit --scope project
+```
+
+### Test locally before installing
+
+```bash
+claude --plugin-dir ./path/to/ai-context-kit
+```
+
+### Available skills after installation
+
+| Skill | What it does |
+|-------|-------------|
+| `create-usercontext-instructions` | Generate a new user context file through structured discovery |
+| `create-agents-md` | Generate a root `AGENTS.md` for any repository |
+| `create-project-instructions` | Generate a project-context `AGENTS.md` with role/phase defaults |
+| `create-skill` | Generate a new canonical `SKILL.md` artifact |
+| `validate-usercontext-instructions` | Validate a user context file with scored report |
+| `validate-agents-md` | Validate a root `AGENTS.md` with scored report |
+| `validate-project-instructions` | Validate a project-context `AGENTS.md` with scored report |
+| `validate-skill` | Validate a `SKILL.md` artifact with scored report |
+| `repository-drift-control` | Check and enforce consistency across spec, templates, and docs |
+
+### Update
+
+```bash
+claude plugin update ai-context-kit
+```
+
+---
 
 ## How It Works
 

--- a/skills/create-agents-md/SKILL.md
+++ b/skills/create-agents-md/SKILL.md
@@ -2,7 +2,7 @@
 name: "create-agents-md"
 description: "Create concise, repository-specific AGENTS.md files with operational contract, precedence rules, and drift-control guidance."
 version: "1.0.0"
-allowed-tools: Read, Write, Edit
+allowed-tools: [Read, Write, Edit]
 metadata:
   source_prompt: "prompts/create-agents-md.prompt.md"
   workflow_type: "generation"

--- a/skills/create-agents-md/SKILL.md
+++ b/skills/create-agents-md/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: "create-agents-md"
 description: "Create concise, repository-specific AGENTS.md files with operational contract, precedence rules, and drift-control guidance."
+version: "1.0.0"
+allowed-tools: Read, Write, Edit
 metadata:
   source_prompt: "prompts/create-agents-md.prompt.md"
   workflow_type: "generation"

--- a/skills/create-project-instructions/SKILL.md
+++ b/skills/create-project-instructions/SKILL.md
@@ -2,7 +2,7 @@
 name: "create-project-instructions"
 description: "Create project-context AGENTS.md files using phased discovery, required operational sections, and session-state modeling."
 version: "1.0.0"
-allowed-tools: Read, Write, Edit
+allowed-tools: [Read, Write, Edit]
 metadata:
   source_prompt: "prompts/create-project-instructions.prompt.md"
   workflow_type: "generation"

--- a/skills/create-project-instructions/SKILL.md
+++ b/skills/create-project-instructions/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: "create-project-instructions"
 description: "Create project-context AGENTS.md files using phased discovery, required operational sections, and session-state modeling."
+version: "1.0.0"
+allowed-tools: Read, Write, Edit
 metadata:
   source_prompt: "prompts/create-project-instructions.prompt.md"
   workflow_type: "generation"

--- a/skills/create-skill/SKILL.md
+++ b/skills/create-skill/SKILL.md
@@ -2,7 +2,7 @@
 name: "create-skill"
 description: "Create canonical SKILL.md artifacts with deterministic schema, workflow, safety, and quality checks."
 version: "1.0.0"
-allowed-tools: Read, Write, Edit
+allowed-tools: [Read, Write, Edit]
 metadata:
   source_prompt: "prompts/create-skill.prompt.md"
   workflow_type: "generation"

--- a/skills/create-skill/SKILL.md
+++ b/skills/create-skill/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: "create-skill"
 description: "Create canonical SKILL.md artifacts with deterministic schema, workflow, safety, and quality checks."
+version: "1.0.0"
+allowed-tools: Read, Write, Edit
 metadata:
   source_prompt: "prompts/create-skill.prompt.md"
   workflow_type: "generation"

--- a/skills/create-skill/references/field-constraints.md
+++ b/skills/create-skill/references/field-constraints.md
@@ -5,10 +5,11 @@
 - `description`
 
 ## Optional frontmatter
+- `version`
 - `license`
 - `compatibility`
 - `metadata`
-- `allowed-tools` (optional/experimental)
+- `allowed-tools`
 
 ## Constraint rules
 - `name`: 1-64 chars, lowercase alphanumeric + hyphen, no leading/trailing hyphen, no consecutive hyphens, matches folder name.

--- a/skills/create-usercontext-instructions/SKILL.md
+++ b/skills/create-usercontext-instructions/SKILL.md
@@ -2,7 +2,7 @@
 name: "create-usercontext-instructions"
 description: "Create complete user-context instruction files using a structured discovery workflow and repository format rules."
 version: "1.0.0"
-allowed-tools: Read, Write, Edit
+allowed-tools: [Read, Write, Edit]
 metadata:
   source_prompt: "prompts/create-usercontext-instructions.prompt.md"
   workflow_type: "generation"

--- a/skills/create-usercontext-instructions/SKILL.md
+++ b/skills/create-usercontext-instructions/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: "create-usercontext-instructions"
 description: "Create complete user-context instruction files using a structured discovery workflow and repository format rules."
+version: "1.0.0"
+allowed-tools: Read, Write, Edit
 metadata:
   source_prompt: "prompts/create-usercontext-instructions.prompt.md"
   workflow_type: "generation"

--- a/skills/repository-drift-control/SKILL.md
+++ b/skills/repository-drift-control/SKILL.md
@@ -2,7 +2,7 @@
 name: "repository-drift-control"
 description: "Enforce coordinated updates across specs, templates, prompts, samples, and docs to prevent repository guidance drift."
 version: "1.0.0"
-allowed-tools: Read, Edit
+allowed-tools: [Read, Edit]
 metadata:
   source_docs: "AGENTS.md, README.md, specs/context_aware_ai_session_spec.md"
   workflow_type: "governance"

--- a/skills/repository-drift-control/SKILL.md
+++ b/skills/repository-drift-control/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: "repository-drift-control"
 description: "Enforce coordinated updates across specs, templates, prompts, samples, and docs to prevent repository guidance drift."
+version: "1.0.0"
+allowed-tools: Read, Edit
 metadata:
   source_docs: "AGENTS.md, README.md, specs/context_aware_ai_session_spec.md"
   workflow_type: "governance"

--- a/skills/validate-agents-md/SKILL.md
+++ b/skills/validate-agents-md/SKILL.md
@@ -2,7 +2,7 @@
 name: "validate-agents-md"
 description: "Validate AGENTS.md files for structural completeness, operational contract coverage, neutrality, and repository alignment."
 version: "1.0.0"
-allowed-tools: Read, Write
+allowed-tools: [Read, Write]
 metadata:
   source_prompt: "prompts/validate-agents-md.prompt.md"
   workflow_type: "validation"

--- a/skills/validate-agents-md/SKILL.md
+++ b/skills/validate-agents-md/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: "validate-agents-md"
 description: "Validate AGENTS.md files for structural completeness, operational contract coverage, neutrality, and repository alignment."
+version: "1.0.0"
+allowed-tools: Read, Write
 metadata:
   source_prompt: "prompts/validate-agents-md.prompt.md"
   workflow_type: "validation"

--- a/skills/validate-project-instructions/SKILL.md
+++ b/skills/validate-project-instructions/SKILL.md
@@ -2,7 +2,7 @@
 name: "validate-project-instructions"
 description: "Validate project-context AGENTS.md files for required sections, session-state model completeness, role quality, and scoring compliance."
 version: "1.0.0"
-allowed-tools: Read, Write
+allowed-tools: [Read, Write]
 metadata:
   source_prompt: "prompts/validate-project-instructions.prompt.md"
   workflow_type: "validation"

--- a/skills/validate-project-instructions/SKILL.md
+++ b/skills/validate-project-instructions/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: "validate-project-instructions"
 description: "Validate project-context AGENTS.md files for required sections, session-state model completeness, role quality, and scoring compliance."
+version: "1.0.0"
+allowed-tools: Read, Write
 metadata:
   source_prompt: "prompts/validate-project-instructions.prompt.md"
   workflow_type: "validation"

--- a/skills/validate-skill/SKILL.md
+++ b/skills/validate-skill/SKILL.md
@@ -2,7 +2,7 @@
 name: "validate-skill"
 description: "Validate SKILL.md artifacts for schema, quality, safety, portability, and scoring compliance."
 version: "1.0.0"
-allowed-tools: Read, Write
+allowed-tools: [Read, Write]
 metadata:
   source_prompt: "prompts/validate-skill.prompt.md"
   workflow_type: "validation"

--- a/skills/validate-skill/SKILL.md
+++ b/skills/validate-skill/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: "validate-skill"
 description: "Validate SKILL.md artifacts for schema, quality, safety, portability, and scoring compliance."
+version: "1.0.0"
+allowed-tools: Read, Write
 metadata:
   source_prompt: "prompts/validate-skill.prompt.md"
   workflow_type: "validation"

--- a/skills/validate-skill/references/phase-checks.md
+++ b/skills/validate-skill/references/phase-checks.md
@@ -14,7 +14,7 @@ Check:
 - `name` format constraints
 - folder-name parity
 - `description` quality constraints
-- optional field constraints (`compatibility`, `metadata`, `allowed-tools`)
+- optional field constraints (`version`, `compatibility`, `metadata`, `allowed-tools`)
 
 ## Phase 3: Instruction Quality And Completeness
 Check:

--- a/skills/validate-usercontext-instructions/SKILL.md
+++ b/skills/validate-usercontext-instructions/SKILL.md
@@ -2,7 +2,7 @@
 name: "validate-usercontext-instructions"
 description: "Validate user-context instruction files against schema, section completeness, quality checks, and scoring criteria."
 version: "1.0.0"
-allowed-tools: Read, Write
+allowed-tools: [Read, Write]
 metadata:
   source_prompt: "prompts/validate-usercontext-instructions.prompt.md"
   workflow_type: "validation"

--- a/skills/validate-usercontext-instructions/SKILL.md
+++ b/skills/validate-usercontext-instructions/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: "validate-usercontext-instructions"
 description: "Validate user-context instruction files against schema, section completeness, quality checks, and scoring criteria."
+version: "1.0.0"
+allowed-tools: Read, Write
 metadata:
   source_prompt: "prompts/validate-usercontext-instructions.prompt.md"
   workflow_type: "validation"

--- a/templates/skill_template/SKILL.md
+++ b/templates/skill_template/SKILL.md
@@ -1,12 +1,13 @@
 ---
 name: "example-skill"
 description: "Briefly describe what this skill does and when it should be used."
+version: "1.0.0"
+allowed-tools: [Read]
 license: "Optional license identifier"
 compatibility: "Optional environment/runtime requirements."
 metadata:
   owner: "Optional owner"
   domain: "Optional domain"
-# allowed-tools: [] # Optional and experimental. Keep disabled by default.
 ---
 
 # Example Skill
@@ -55,6 +56,5 @@ Describe the capability this skill provides and the problem it solves.
 - 1-500 characters.
 - Use only for real environment constraints.
 - `metadata` (optional): map of string keys to string values.
-- `allowed-tools` (optional/experimental):
-- Parseable if present.
-- Keep disabled by default unless explicitly enabled by policy.
+- `version` (optional): semver string (e.g. `"1.0.0"`). Increment when skill behavior changes.
+- `allowed-tools` (optional): YAML flow list of tool names this skill may invoke (e.g. `[Read, Write, Edit]`).


### PR DESCRIPTION
## Summary
This PR adds native Claude Code plugin support to AI Context Kit, enabling users to install and use all 9 skills directly in Claude Code sessions without cloning the repository. It also standardizes skill metadata across all skill artifacts.

## Key Changes

- **Added Claude Code plugin manifest** (`.claude-plugin/plugin.json`): Defines the plugin with metadata, version 1.4.0, and keywords for discoverability in the Claude Code plugin registry
- **Updated README with plugin installation guide**: New section documenting how to install the plugin at user or project scope, test locally, and update it
- **Added skill metadata to all 9 SKILL.md files**: Each skill now includes:
  - `version: "1.0.0"` field for version tracking
  - `allowed-tools` field specifying required permissions (Read, Write, Edit as appropriate for each skill's function)
- **Standardized skill frontmatter**: All skills now follow a consistent metadata structure compatible with the Claude Code plugin system

## Implementation Details

- The plugin manifest references the official JSON schema for Claude Code plugin manifests
- Allowed-tools permissions are granular: generation skills require Read/Write/Edit, validation skills require Read/Write, and the drift-control governance skill requires Read/Edit only
- The installation instructions support both user-scope (global) and project-scope installations
- Plugin can be tested locally before installation using the `--plugin-dir` flag
- All changes are backward compatible; existing repository usage patterns remain unchanged

https://claude.ai/code/session_01QTwxzD9j8ds3W1kq6dQ2UX