### PR TITLE
Add GitHub Copilot CLI plugin support via marketplace.json

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,29 @@
+{
+  "name": "ai-context-kit",
+  "description": "Context-aware AI collaboration skills for creating and validating user context, project AGENTS.md files, and skill artifacts across LLM providers.",
+  "owner": {
+    "name": "MSiccDev Software Development"
+  },
+  "plugins": [
+    {
+      "name": "ai-context-kit",
+      "source": {
+        "source": "github",
+        "repo": "MSiccDev/ai-context-kit"
+      },
+      "description": "Context-aware AI collaboration skills for creating and validating user context, project AGENTS.md files, and skill artifacts across LLM providers.",
+      "version": "1.4.0",
+      "license": "MIT",
+      "homepage": "https://github.com/MSiccDev/ai-context-kit",
+      "repository": "https://github.com/MSiccDev/ai-context-kit",
+      "keywords": [
+        "context",
+        "agents",
+        "skills",
+        "user-context",
+        "ai-collaboration",
+        "prompt-engineering"
+      ]
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -296,20 +296,32 @@ If paths must change, update the specification and README first, then adjust ski
 
 ---
 
-## Installing as a Claude Code Plugin
+## Installing as a Plugin (Claude Code and GitHub Copilot CLI)
 
-AI Context Kit is distributed as a native Claude Code plugin. Installing it gives you all 9 skills available directly in your Claude Code sessions without cloning or forking the repository.
+AI Context Kit is distributed as a plugin compatible with both Claude Code and GitHub Copilot CLI — they share the same plugin spec. Installing gives you all 9 skills without cloning or forking the repository.
 
-### Install
+### Claude Code
+
+Register the marketplace (one-time) and install:
 
 ```bash
-claude plugin install ai-context-kit@MSiccDev/ai-context-kit
+claude plugin marketplace add MSiccDev/ai-context-kit
+claude plugin install ai-context-kit@ai-context-kit
 ```
 
-This installs the plugin at user scope (`~/.claude/settings.json`). To install for a specific project only:
+To install for a specific project only (shared via `.claude/settings.json`):
 
 ```bash
-claude plugin install ai-context-kit@MSiccDev/ai-context-kit --scope project
+claude plugin install ai-context-kit@ai-context-kit --scope project
+```
+
+### GitHub Copilot CLI
+
+The install commands are identical — the plugin spec is shared:
+
+```bash
+copilot plugin marketplace add MSiccDev/ai-context-kit
+copilot plugin install ai-context-kit@ai-context-kit
 ```
 
 ### Test locally before installing
@@ -318,7 +330,14 @@ claude plugin install ai-context-kit@MSiccDev/ai-context-kit --scope project
 claude --plugin-dir ./path/to/ai-context-kit
 ```
 
-### Available skills after installation
+### Invoking skills after installation
+
+Skills are namespaced to the plugin name. Inside a session:
+
+```
+/ai-context-kit:create-usercontext-instructions
+/ai-context-kit:validate-agents-md
+```
 
 | Skill | What it does |
 |-------|-------------|

--- a/README.md
+++ b/README.md
@@ -298,7 +298,7 @@ If paths must change, update the specification and README first, then adjust ski
 
 ## Installing as a Plugin (Claude Code and GitHub Copilot CLI)
 
-AI Context Kit is distributed as a plugin compatible with both Claude Code and GitHub Copilot CLI — they share the same plugin spec. Installing gives you all 9 skills without cloning or forking the repository.
+AI Context Kit is distributed as a plugin compatible with both Claude Code and GitHub Copilot CLI — they share the same plugin spec. Installing registers all 9 skills as namespaced slash commands in the plugin runtime, with no manual `SKILL.md` loading required.
 
 ### Claude Code
 
@@ -331,6 +331,8 @@ claude --plugin-dir ./path/to/ai-context-kit
 ```
 
 ### Invoking skills after installation
+
+> **Plugin runtime vs. manual invocation:** This section covers invocation when the plugin is installed via the plugin system (Claude Code or Copilot CLI). If you are using the repository directly (cloned or forked), see [Invoking Skills](#invoking-skills) above — that approach requires loading each `SKILL.md` manually into your session.
 
 Skills are namespaced to the plugin name. Inside a session:
 


### PR DESCRIPTION
## Summary

- Adds `.claude-plugin/marketplace.json` to turn the repository into a self-hosted plugin marketplace, enabling `copilot plugin marketplace add MSiccDev/ai-context-kit` installation
- Updates README install section from "Claude Code Plugin" to "Installing as a Plugin (Claude Code and GitHub Copilot CLI)" — both runtimes share the same plugin spec
- Documents namespaced skill invocation (`/ai-context-kit:skill-name`), `--scope project` option, and `copilot plugin` equivalents for all install/update commands

## Why marketplace.json

Claude Code and GitHub Copilot CLI share the same plugin spec (`.claude-plugin/plugin.json`). The `marketplace.json` file is the additional artifact that enables self-hosted marketplace discovery for Copilot CLI users, so both runtimes can install from the same source without cloning or forking.

## Test plan

- [ ] Verify `.claude-plugin/marketplace.json` is valid JSON and fields match `plugin.json` version (`1.4.0`)
- [ ] Verify README install section renders correctly (bash blocks, table, namespaced skill examples)
- [ ] Confirm `copilot plugin marketplace add MSiccDev/ai-context-kit` install flow reads from `marketplace.json`
- [ ] Confirm `claude plugin marketplace add MSiccDev/ai-context-kit` still works (no regression)

https://claude.ai/code/session_01QTwxzD9j8ds3W1kq6dQ2UX

---
_Generated by [Claude Code](https://claude.ai/code/session_01QTwxzD9j8ds3W1kq6dQ2UX)_