### PR TITLE
chore(plugin): add Codex plugin packaging

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,0 +1,20 @@
+{
+  "name": "ai-context-kit",
+  "interface": {
+    "displayName": "AI Context Kit"
+  },
+  "plugins": [
+    {
+      "name": "ai-context-kit",
+      "source": {
+        "source": "local",
+        "path": "./"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Productivity"
+    }
+  ]
+}

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,0 +1,41 @@
+{
+  "name": "ai-context-kit",
+  "version": "1.4.2",
+  "description": "Context-aware AI collaboration skills and implementation loop prompts for creating and validating user context, project AGENTS.md files, and skill artifacts across LLM providers.",
+  "author": {
+    "name": "MSiccDev Software Development",
+    "url": "https://github.com/MSiccDev"
+  },
+  "homepage": "https://github.com/MSiccDev/ai-context-kit",
+  "repository": "https://github.com/MSiccDev/ai-context-kit",
+  "license": "MIT",
+  "keywords": [
+    "context",
+    "agents",
+    "skills",
+    "user-context",
+    "ai-collaboration",
+    "prompt-engineering",
+    "implementation-loop",
+    "workflow-prompts"
+  ],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "AI Context Kit",
+    "shortDescription": "AGENTS-first collaboration skills for Codex.",
+    "longDescription": "Reusable skills for creating and validating user context, project AGENTS.md files, and skill artifacts across LLM providers.",
+    "developerName": "MSiccDev Software Development",
+    "category": "Productivity",
+    "capabilities": [
+      "Read",
+      "Write"
+    ],
+    "websiteURL": "https://github.com/MSiccDev/ai-context-kit",
+    "defaultPrompt": [
+      "Use AI Context Kit to create a project AGENTS.md.",
+      "Validate this AGENTS.md with AI Context Kit.",
+      "Create a user context file with AI Context Kit."
+    ],
+    "brandColor": "#2563EB"
+  }
+}

--- a/README.md
+++ b/README.md
@@ -67,6 +67,13 @@ ai-context-kit/
 ├── README.md                                         # This file
 ├── LICENSE                                           # MIT License file
 │
+├── .codex-plugin/
+│   └── plugin.json                                   # Codex plugin manifest
+├── .agents/
+│   ├── plugins/
+│   │   └── marketplace.json                          # Repo-scoped Codex marketplace
+│   └── skills/                                       # Codex skill discovery symlinks
+│
 ├── prompts/                                          # Prompt wrappers and implementation loop
 │   ├── skills/                                       # Skill-wrapper prompts (route to canonical skills)
 │   │   ├── create-usercontext-instructions.prompt.md # Generate user context instruction files
@@ -307,9 +314,21 @@ If paths must change, update the specification and README first, then adjust ski
 
 ---
 
-## Installing as a Plugin (Claude Code and GitHub Copilot CLI)
+## Installing as a Plugin
 
-AI Context Kit is distributed as a plugin compatible with both Claude Code and GitHub Copilot CLI — they share the same plugin spec. Installing registers all 9 skills as namespaced slash commands in the plugin runtime, with no manual `SKILL.md` loading required.
+AI Context Kit ships native plugin metadata for Codex and compatibility metadata for Claude Code and GitHub Copilot CLI. Installing registers all 11 skills in the target runtime, with no manual `SKILL.md` loading required.
+
+### OpenAI Codex
+
+Register the repository as a marketplace source:
+
+```bash
+codex plugin marketplace add MSiccDev/ai-context-kit
+```
+
+Then restart Codex, open **Plugins**, choose the **AI Context Kit** marketplace, and install `ai-context-kit`.
+
+This repository also supports repo-scoped skill discovery for direct local use. If you clone the repository and run Codex inside it, the `.agents/skills/` symlinks expose the canonical `skills/` directory without duplicating content.
 
 ### Claude Code
 
@@ -343,7 +362,7 @@ claude --plugin-dir ./path/to/ai-context-kit
 
 ### Invoking skills after installation
 
-> **Plugin runtime vs. manual invocation:** This section covers invocation when the plugin is installed via the plugin system (Claude Code or Copilot CLI). If you are using the repository directly (cloned or forked), see [Invoking Skills](#invoking-skills) above — that approach requires loading each `SKILL.md` manually into your session.
+> **Plugin runtime vs. manual invocation:** This section covers invocation when the plugin is installed via the plugin system. If you are using the repository directly (cloned or forked), see [Invoking Skills](#invoking-skills) above, or use Codex repo-scoped skill discovery through `.agents/skills/`.
 
 Skills are namespaced to the plugin name. Inside a session:
 
@@ -376,13 +395,13 @@ claude plugin update ai-context-kit
 
 ## Using with OpenAI Codex
 
-Codex auto-discovers skills from the `.agents/skills/` directory (scanned upward from the current working directory to the repo root). AI Context Kit ships a `.agents/skills/` directory whose entries are symlinks to the canonical `skills/` folder — no content duplication, single source of truth.
+Codex auto-discovers skills from the `.agents/skills/` directory, scanning upward from the current working directory to the repo root. AI Context Kit ships a `.agents/skills/` directory whose entries are symlinks to the canonical `skills/` folders, so repo-local skill discovery and plugin packaging both point at the same source of truth.
 
 Each skill also includes an `agents/openai.yaml` sidecar (`skills/<name>/agents/openai.yaml`) with UI metadata consumed by the Codex skill picker.
 
 ### Auto-discovery (no install needed)
 
-If you clone this repo and run Codex from within it, all 9 skills are discovered automatically — no registration or import required.
+If you clone this repo and run Codex from within it, all 11 skills are discovered automatically. No registration or import is required for repo-local use.
 
 ### Invoking skills in Codex
 
@@ -396,9 +415,13 @@ $repository-drift-control
 
 `repository-drift-control` requires explicit invocation (`allow_implicit_invocation: false`) since it is a governance action.
 
+### Installing the plugin instead of using repo-local discovery
+
+If you want the skills available outside this repository without copying `.agents/skills/` into each project, install the plugin from the Codex marketplace flow described above.
+
 ### Using skills in your own project
 
-To make these skills available when working in a different project, add the skill path to your Codex configuration, or copy/symlink the `.agents/skills/` directory into your project root.
+To make these skills available when working in a different project without installing the plugin, add the skill path to your Codex configuration, or copy or symlink the `.agents/skills/` directory into your project root.
 
 > **Note for Windows users:** Git symlink support must be enabled **before** checkout — otherwise git materialises symlinks as plain text files. Enable it at clone time:
 > ```bash


### PR DESCRIPTION
## Summary
- add a native Codex plugin manifest at `.codex-plugin/plugin.json`
- add a repo-scoped Codex marketplace at `.agents/plugins/marketplace.json`
- update the README to document Codex installation, repo-local skill discovery, and the correct skill count

## Why
The repository already exposed the skill content, but it was missing native Codex plugin packaging. This change makes the repo installable from Codex as a plugin while keeping the existing repo-local `.agents/skills` discovery path.

## User impact
- Codex users can add `MSiccDev/ai-context-kit` as a marketplace source and install the plugin from the Plugins UI
- developers opening the repo directly still get repo-scoped skill discovery through `.agents/skills`
- the README now reflects the actual repository layout and the current Codex workflow

## Validation
- `python3 /Users/msicc/.codex/skills/.system/plugin-creator/scripts/validate_plugin.py /Users/msicc/Documents/Codex/2026-07-07/ho/work/ai-context-kit`