### PR TITLE
chore(skills): remove openai sidecars

### DIFF
--- a/skills/create-agents-md/agents/openai.yaml
+++ b/skills/create-agents-md/agents/openai.yaml
@@ -1,7 +1,0 @@
-interface:
-  display_name: "Create AGENTS.md"
-  short_description: "Generate a root AGENTS.md for any repo"
-  default_prompt: "Use create-agents-md to generate an AGENTS.md file for this repository"
-
-policy:
-  allow_implicit_invocation: true

--- a/skills/create-checkpoint/agents/openai.yaml
+++ b/skills/create-checkpoint/agents/openai.yaml
@@ -1,7 +1,0 @@
-interface:
-  display_name: "Create Checkpoint"
-  short_description: "Capture session state as a checkpoint file"
-  default_prompt: "Use create-checkpoint to capture the current session state before ending"
-
-policy:
-  allow_implicit_invocation: false

--- a/skills/create-project-instructions/agents/openai.yaml
+++ b/skills/create-project-instructions/agents/openai.yaml
@@ -1,7 +1,0 @@
-interface:
-  display_name: "Create Project Instructions"
-  short_description: "Generate a project-context AGENTS.md"
-  default_prompt: "Use create-project-instructions to generate a project AGENTS.md with role and phase defaults"
-
-policy:
-  allow_implicit_invocation: true

--- a/skills/create-skill/agents/openai.yaml
+++ b/skills/create-skill/agents/openai.yaml
@@ -1,7 +1,0 @@
-interface:
-  display_name: "Create Skill"
-  short_description: "Generate a new canonical SKILL.md file"
-  default_prompt: "Use create-skill to generate a new SKILL.md artifact for a workflow skill"
-
-policy:
-  allow_implicit_invocation: true

--- a/skills/create-usercontext-instructions/agents/openai.yaml
+++ b/skills/create-usercontext-instructions/agents/openai.yaml
@@ -1,7 +1,0 @@
-interface:
-  display_name: "Create User Context"
-  short_description: "Create a user context instructions file"
-  default_prompt: "Use create-usercontext-instructions to create a user context file through structured discovery"
-
-policy:
-  allow_implicit_invocation: true

--- a/skills/repository-drift-control/agents/openai.yaml
+++ b/skills/repository-drift-control/agents/openai.yaml
@@ -1,7 +1,0 @@
-interface:
-  display_name: "Repository Drift Control"
-  short_description: "Check spec, template, and doc alignment"
-  default_prompt: "Use repository-drift-control to check and enforce consistency across spec, templates, and docs"
-
-policy:
-  allow_implicit_invocation: false

--- a/skills/restore-checkpoint/agents/openai.yaml
+++ b/skills/restore-checkpoint/agents/openai.yaml
@@ -1,7 +1,0 @@
-interface:
-  display_name: "Restore Checkpoint"
-  short_description: "Restore session state from a checkpoint file"
-  default_prompt: "Use restore-checkpoint to restore session state from a checkpoint artifact"
-
-policy:
-  allow_implicit_invocation: false

--- a/skills/validate-agents-md/agents/openai.yaml
+++ b/skills/validate-agents-md/agents/openai.yaml
@@ -1,7 +1,0 @@
-interface:
-  display_name: "Validate AGENTS.md"
-  short_description: "Validate an AGENTS.md with scored report"
-  default_prompt: "Use validate-agents-md to validate this AGENTS.md file and produce a scored compliance report"
-
-policy:
-  allow_implicit_invocation: true

--- a/skills/validate-project-instructions/agents/openai.yaml
+++ b/skills/validate-project-instructions/agents/openai.yaml
@@ -1,7 +1,0 @@
-interface:
-  display_name: "Validate Project Instructions"
-  short_description: "Validate a project AGENTS.md with scores"
-  default_prompt: "Use validate-project-instructions to validate a project-context AGENTS.md and produce a scored report"
-
-policy:
-  allow_implicit_invocation: true

--- a/skills/validate-skill/agents/openai.yaml
+++ b/skills/validate-skill/agents/openai.yaml
@@ -1,7 +1,0 @@
-interface:
-  display_name: "Validate Skill"
-  short_description: "Validate a SKILL.md with scored report"
-  default_prompt: "Use validate-skill to validate this SKILL.md artifact and produce a scored compliance report"
-
-policy:
-  allow_implicit_invocation: true

--- a/skills/validate-usercontext-instructions/agents/openai.yaml
+++ b/skills/validate-usercontext-instructions/agents/openai.yaml
@@ -1,7 +1,0 @@
-interface:
-  display_name: "Validate User Context"
-  short_description: "Validate user context file with scores"
-  default_prompt: "Use validate-usercontext-instructions to validate a user context file and produce a scored compliance report"
-
-policy:
-  allow_implicit_invocation: true


### PR DESCRIPTION
## Summary
- remove `skills/*/agents/openai.yaml` sidecars from the shipped skills
- keep the canonical `SKILL.md` files and Codex plugin packaging unchanged

## Why
These sidecars were only carrying lightweight Codex UI metadata and an explicit `allow_implicit_invocation: true` setting, which matches the documented default behavior. They were not required for plugin installation or core skill discovery, so removing them reduces maintenance overhead without changing the main workflow.

## User impact
- skill loading and plugin installation continue to work through the existing `SKILL.md` files and plugin packaging
- Codex falls back to the normal skill metadata path instead of the optional sidecar files
- repository maintenance is simpler because there is one less per-skill metadata file to keep in sync

## Validation
- verified that no `skills/*/agents/openai.yaml` files remain in the worktree
- no code or runtime behavior changed beyond removing optional metadata files